### PR TITLE
feat(auth): OTP auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/mapped-types": "*",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/terminus": "^11.0.0",
+        "@nestjs/throttler": "^6.4.0",
         "@prisma/client": "^6.13.0",
         "@redis/client": "^5.8.3",
         "@types/multer": "^2.0.0",
@@ -2941,6 +2942,16 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@noble/hashes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/terminus": "^11.0.0",
         "@prisma/client": "^6.13.0",
+        "@redis/client": "^5.8.3",
         "@types/multer": "^2.0.0",
         "axios": "^1.11.0",
         "bcrypt": "^6.0.0",
@@ -3115,6 +3116,17 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.13.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.8.3.tgz",
+      "integrity": "sha512-MZVUE+l7LmMIYlIjubPosruJ9ltSLGFmJqsXApTqPLyHLjsJUSAbAJb/A3N34fEqean4ddiDkdWzNu4ZKPvRUg==",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/terminus": "^11.0.0",
     "@prisma/client": "^6.13.0",
+    "@redis/client": "^5.8.3",
     "@types/multer": "^2.0.0",
     "axios": "^1.11.0",
     "bcrypt": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/terminus": "^11.0.0",
+    "@nestjs/throttler": "^6.4.0",
     "@prisma/client": "^6.13.0",
     "@redis/client": "^5.8.3",
     "@types/multer": "^2.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { FeaturesModule } from './modules/features/features.module';
 import { HealthModule } from './modules/health/health.module';
 import { StorageModule } from './modules/storage/storage.module';
 import { UsersModule } from './modules/users/users.module';
+import { RedisModule } from './modules/redis/redis.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { UsersModule } from './modules/users/users.module';
     HealthModule,
     EmailsModule,
     StorageModule,
+    RedisModule,
   ],
 })
 export class AppModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,11 +8,18 @@ import { HealthModule } from './modules/health/health.module';
 import { StorageModule } from './modules/storage/storage.module';
 import { UsersModule } from './modules/users/users.module';
 import { RedisModule } from './modules/redis/redis.module';
+import { ThrottlerModule } from '@nestjs/throttler';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
     BullModule.forRoot({ connection: { host: 'localhost', port: 6379 } }),
+    ThrottlerModule.forRoot([
+      {
+        ttl: 60000,
+        limit: 60,
+      },
+    ]),
     UsersModule,
     AuthModule,
     FeaturesModule,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,7 +8,7 @@ import { HealthModule } from './modules/health/health.module';
 import { StorageModule } from './modules/storage/storage.module';
 import { UsersModule } from './modules/users/users.module';
 import { RedisModule } from './modules/redis/redis.module';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule, seconds } from '@nestjs/throttler';
 
 @Module({
   imports: [
@@ -16,7 +16,7 @@ import { ThrottlerModule } from '@nestjs/throttler';
     BullModule.forRoot({ connection: { host: 'localhost', port: 6379 } }),
     ThrottlerModule.forRoot([
       {
-        ttl: 60000,
+        ttl: seconds(60),
         limit: 60,
       },
     ]),

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './modules/auth/auth.module';
 import { EmailsModule } from './modules/emails/emails.module';
@@ -8,7 +9,7 @@ import { HealthModule } from './modules/health/health.module';
 import { StorageModule } from './modules/storage/storage.module';
 import { UsersModule } from './modules/users/users.module';
 import { RedisModule } from './modules/redis/redis.module';
-import { ThrottlerModule, seconds } from '@nestjs/throttler';
+import { ThrottlerGuard, ThrottlerModule, seconds } from '@nestjs/throttler';
 
 @Module({
   imports: [
@@ -27,6 +28,12 @@ import { ThrottlerModule, seconds } from '@nestjs/throttler';
     EmailsModule,
     StorageModule,
     RedisModule,
+  ],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/src/modules/auth/auth.constants.ts
+++ b/src/modules/auth/auth.constants.ts
@@ -1,0 +1,1 @@
+export const AUTH_NO_PASSWORD = 'no-password';

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { BasicAuthModule } from './basic/basic-auth.module';
 import { GeneralAuthModule } from './general/general-auth.module';
 import { VkAuthModule } from './vk/vk-auth.module';
+import { OtpAuthModule } from './otp/otp-auth.module';
 
 @Module({
-  imports: [GeneralAuthModule, BasicAuthModule, VkAuthModule],
+  imports: [GeneralAuthModule, BasicAuthModule, VkAuthModule, OtpAuthModule],
 })
 export class AuthModule {}

--- a/src/modules/auth/basic/basic-auth.controller.ts
+++ b/src/modules/auth/basic/basic-auth.controller.ts
@@ -3,6 +3,7 @@ import { Response } from 'express';
 import { BasicAuthService } from './basic-auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { Throttle } from '@nestjs/throttler';
 
 @Controller('/auth/basic')
 export class BasicAuthController {
@@ -13,6 +14,7 @@ export class BasicAuthController {
     return this.basicAuthService.register(dto);
   }
 
+  @Throttle({ default: { limit: 15, ttl: 60000 } })
   @Post('/login')
   async login(
     @Body() dto: LoginDto,

--- a/src/modules/auth/basic/basic-auth.controller.ts
+++ b/src/modules/auth/basic/basic-auth.controller.ts
@@ -3,7 +3,7 @@ import { Response } from 'express';
 import { BasicAuthService } from './basic-auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
-import { Throttle } from '@nestjs/throttler';
+import { Throttle, seconds } from '@nestjs/throttler';
 
 @Controller('/auth/basic')
 export class BasicAuthController {
@@ -14,7 +14,7 @@ export class BasicAuthController {
     return this.basicAuthService.register(dto);
   }
 
-  @Throttle({ default: { limit: 15, ttl: 60000 } })
+  @Throttle({ default: { limit: 15, ttl: seconds(60) } })
   @Post('/login')
   async login(
     @Body() dto: LoginDto,

--- a/src/modules/auth/basic/basic-auth.controller.ts
+++ b/src/modules/auth/basic/basic-auth.controller.ts
@@ -3,18 +3,19 @@ import { Response } from 'express';
 import { BasicAuthService } from './basic-auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
-import { Throttle, seconds } from '@nestjs/throttler';
+import { Throttle, hours, seconds } from '@nestjs/throttler';
 
 @Controller('/auth/basic')
 export class BasicAuthController {
   constructor(private readonly basicAuthService: BasicAuthService) {}
 
+  @Throttle({ default: { limit: 5, ttl: hours(1) } })
   @Post('/register')
   register(@Body() dto: RegisterDto) {
     return this.basicAuthService.register(dto);
   }
 
-  @Throttle({ default: { limit: 15, ttl: seconds(60) } })
+  @Throttle({ default: { limit: 5, ttl: seconds(60) } })
   @Post('/login')
   async login(
     @Body() dto: LoginDto,

--- a/src/modules/auth/otp/dto/otp-auth.dto.ts
+++ b/src/modules/auth/otp/dto/otp-auth.dto.ts
@@ -1,9 +1,5 @@
-import {
-  IsEmail,
-  IsNotEmpty,
-  IsNumberString,
-  MinLength,
-} from 'class-validator';
+import { IsEmail, IsNotEmpty, IsNumberString, Length } from 'class-validator';
+import { OTP_CODE_LENGTH } from '../otp-auth.constants';
 
 export class OtpAuthDto {
   @IsNotEmpty()
@@ -12,6 +8,6 @@ export class OtpAuthDto {
 
   @IsNotEmpty()
   @IsNumberString()
-  @MinLength(3)
+  @Length(OTP_CODE_LENGTH)
   code: string;
 }

--- a/src/modules/auth/otp/dto/otp-auth.dto.ts
+++ b/src/modules/auth/otp/dto/otp-auth.dto.ts
@@ -1,0 +1,17 @@
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsNumberString,
+  MinLength,
+} from 'class-validator';
+
+export class OtpAuthDto {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @IsNotEmpty()
+  @IsNumberString()
+  @MinLength(3)
+  code: string;
+}

--- a/src/modules/auth/otp/dto/send-code.dto.ts
+++ b/src/modules/auth/otp/dto/send-code.dto.ts
@@ -1,0 +1,7 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class OtpAuthSendCodeDto {
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+}

--- a/src/modules/auth/otp/otp-auth.constants.ts
+++ b/src/modules/auth/otp/otp-auth.constants.ts
@@ -1,0 +1,2 @@
+export const OTP_CODE_LIFETIME = 5000;
+export const OTP_CODE_PREFIX = 'otp';

--- a/src/modules/auth/otp/otp-auth.constants.ts
+++ b/src/modules/auth/otp/otp-auth.constants.ts
@@ -1,2 +1,3 @@
 export const OTP_CODE_LIFETIME = 5000;
 export const OTP_CODE_PREFIX = 'otp';
+export const OTP_CODE_LENGTH = 6;

--- a/src/modules/auth/otp/otp-auth.constants.ts
+++ b/src/modules/auth/otp/otp-auth.constants.ts
@@ -1,3 +1,4 @@
-export const OTP_CODE_LIFETIME = 5000;
+export const OTP_CODE_TTL = 300; // seconds
 export const OTP_CODE_PREFIX = 'otp';
 export const OTP_CODE_LENGTH = 6;
+export const OTP_LOCK_TYPE = 'default';

--- a/src/modules/auth/otp/otp-auth.controller.ts
+++ b/src/modules/auth/otp/otp-auth.controller.ts
@@ -2,7 +2,9 @@ import { Body, Post, Controller } from '@nestjs/common';
 import { OtpAuthService } from './otp-auth.service';
 import { OtpAuthSendCodeDto } from './dto/send-code.dto';
 import { OtpAuthDto } from './dto/otp-auth.dto';
+import { Throttle } from '@nestjs/throttler';
 
+@Throttle({ default: { limit: 10, ttl: 60000 } })
 @Controller('/auth/otp')
 export class OtpAuthController {
   constructor(private readonly otpAuthService: OtpAuthService) {}

--- a/src/modules/auth/otp/otp-auth.controller.ts
+++ b/src/modules/auth/otp/otp-auth.controller.ts
@@ -1,0 +1,19 @@
+import { Body, Post, Controller } from '@nestjs/common';
+import { OtpAuthService } from './otp-auth.service';
+import { OtpAuthSendCodeDto } from './dto/send-code.dto';
+import { OtpAuthDto } from './dto/otp-auth.dto';
+
+@Controller('/auth/otp')
+export class OtpAuthController {
+  constructor(private readonly otpAuthService: OtpAuthService) {}
+
+  @Post('/login')
+  async login(@Body() dto: OtpAuthDto) {
+    return await this.otpAuthService.auth(dto);
+  }
+
+  @Post('/send-code')
+  async sendCode(@Body() dto: OtpAuthSendCodeDto) {
+    await this.otpAuthService.sendCode(dto);
+  }
+}

--- a/src/modules/auth/otp/otp-auth.controller.ts
+++ b/src/modules/auth/otp/otp-auth.controller.ts
@@ -4,7 +4,7 @@ import { OtpAuthSendCodeDto } from './dto/send-code.dto';
 import { OtpAuthDto } from './dto/otp-auth.dto';
 import { Throttle, seconds } from '@nestjs/throttler';
 
-@Throttle({ default: { limit: 10, ttl: seconds(60) } })
+@Throttle({ default: { limit: 5, ttl: seconds(60) } })
 @Controller('/auth/otp')
 export class OtpAuthController {
   constructor(private readonly otpAuthService: OtpAuthService) {}

--- a/src/modules/auth/otp/otp-auth.controller.ts
+++ b/src/modules/auth/otp/otp-auth.controller.ts
@@ -2,9 +2,9 @@ import { Body, Post, Controller } from '@nestjs/common';
 import { OtpAuthService } from './otp-auth.service';
 import { OtpAuthSendCodeDto } from './dto/send-code.dto';
 import { OtpAuthDto } from './dto/otp-auth.dto';
-import { Throttle } from '@nestjs/throttler';
+import { Throttle, seconds } from '@nestjs/throttler';
 
-@Throttle({ default: { limit: 10, ttl: 60000 } })
+@Throttle({ default: { limit: 10, ttl: seconds(60) } })
 @Controller('/auth/otp')
 export class OtpAuthController {
   constructor(private readonly otpAuthService: OtpAuthService) {}

--- a/src/modules/auth/otp/otp-auth.module.ts
+++ b/src/modules/auth/otp/otp-auth.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { OtpAuthService } from './otp-auth.service';
+import { OtpAuthController } from './otp-auth.controller';
+import { PrismaService } from 'src/modules/prisma/prisma.service';
+import { CryptService } from 'src/modules/crypt/crypt.service';
+import { RedisModule } from 'src/modules/redis/redis.module';
+import { EmailsModule } from 'src/modules/emails/emails.module';
+import { GeneralAuthModule } from '../general/general-auth.module';
+
+@Module({
+  imports: [RedisModule, EmailsModule, GeneralAuthModule],
+  controllers: [OtpAuthController],
+  providers: [OtpAuthService, PrismaService, CryptService],
+})
+export class OtpAuthModule {}

--- a/src/modules/auth/otp/otp-auth.module.ts
+++ b/src/modules/auth/otp/otp-auth.module.ts
@@ -6,9 +6,10 @@ import { CryptService } from 'src/modules/crypt/crypt.service';
 import { RedisModule } from 'src/modules/redis/redis.module';
 import { EmailsModule } from 'src/modules/emails/emails.module';
 import { GeneralAuthModule } from '../general/general-auth.module';
+import { AuthProtectionModule } from '../protection/auth-protection.module';
 
 @Module({
-  imports: [RedisModule, EmailsModule, GeneralAuthModule],
+  imports: [RedisModule, EmailsModule, GeneralAuthModule, AuthProtectionModule],
   controllers: [OtpAuthController],
   providers: [OtpAuthService, PrismaService, CryptService],
 })

--- a/src/modules/auth/otp/otp-auth.service.ts
+++ b/src/modules/auth/otp/otp-auth.service.ts
@@ -1,0 +1,117 @@
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { OtpAuthSendCodeDto } from './dto/send-code.dto';
+import { PrismaService } from 'src/modules/prisma/prisma.service';
+import { CryptService } from 'src/modules/crypt/crypt.service';
+import { RedisService } from 'src/modules/redis/redis.service';
+import { OTP_CODE_LIFETIME, OTP_CODE_PREFIX } from './otp-auth.constants';
+import { EmailsService } from 'src/modules/emails/emails.service';
+import { EMAIL_TEMPLATE } from 'src/modules/emails/emails.constants';
+import { AUTH_NO_PASSWORD } from '../auth.constants';
+import { GeneralAuthService } from '../general/general-auth.service';
+import { OtpAuthDto } from './dto/otp-auth.dto';
+
+@Injectable()
+export class OtpAuthService {
+  constructor(
+    private readonly cryptService: CryptService,
+    private readonly prisma: PrismaService,
+    private readonly redisSerivce: RedisService,
+    private readonly emailsService: EmailsService,
+    private readonly generalAuthService: GeneralAuthService,
+  ) {}
+
+  async auth(dto: OtpAuthDto, isRegistrationAllowed = false) {
+    await this.checkValidityCode(dto);
+
+    let user = await this.prisma.user.findUnique({
+      where: { email: dto.email },
+    });
+
+    if (!user) {
+      if (isRegistrationAllowed) {
+        user = await this.register(dto);
+      } else {
+        throw new UnauthorizedException('User not found');
+      }
+    }
+
+    return this.generalAuthService.generateTokensPair({ sub: user.id });
+  }
+
+  async sendCode({ email }: OtpAuthSendCodeDto) {
+    const otpCode = await this.cryptService.generateHashedNumCode();
+
+    try {
+      await this.redisSerivce.set(`${OTP_CODE_PREFIX}:${email}`, otpCode, {
+        EX: OTP_CODE_LIFETIME,
+      });
+    } catch {
+      throw new InternalServerErrorException('Failed to save OTP code');
+    }
+
+    try {
+      await this.emailsService.sendEmail({
+        templateId: EMAIL_TEMPLATE.REGISTER,
+        email,
+        variables: { test: email },
+      });
+    } catch (e) {
+      console.log('OTP Code. Something went wrong when sending email:', {
+        e,
+        email,
+      });
+    }
+  }
+
+  private async register(dto: OtpAuthDto) {
+    const user = await this.prisma.user.create({
+      data: {
+        email: dto.email,
+        hashedPassword: AUTH_NO_PASSWORD,
+      },
+    });
+
+    try {
+      await this.emailsService.sendEmail({
+        templateId: EMAIL_TEMPLATE.REGISTER,
+        email: dto.email,
+        variables: { test: dto.email },
+      });
+    } catch (e) {
+      console.log(
+        'User registration using OTP code. Something went wrong when sending email:',
+        {
+          e,
+          email: dto.email,
+        },
+      );
+    }
+
+    return user;
+  }
+
+  private async checkValidityCode({ email, code }: OtpAuthDto) {
+    let otpCode: string | null = null;
+
+    try {
+      otpCode = await this.redisSerivce.get(`${OTP_CODE_PREFIX}:${email}`);
+    } catch {
+      throw new InternalServerErrorException('Failed to get OTP code');
+    }
+
+    if (!otpCode) throw new BadRequestException('Code is invalid');
+
+    const isSameCode = await this.cryptService.compare(code, otpCode);
+
+    if (!isSameCode) {
+      throw new BadRequestException('Code is incorrect');
+    }
+
+    return otpCode;
+  }
+}

--- a/src/modules/auth/otp/otp-auth.service.ts
+++ b/src/modules/auth/otp/otp-auth.service.ts
@@ -8,7 +8,11 @@ import { OtpAuthSendCodeDto } from './dto/send-code.dto';
 import { PrismaService } from 'src/modules/prisma/prisma.service';
 import { CryptService } from 'src/modules/crypt/crypt.service';
 import { RedisService } from 'src/modules/redis/redis.service';
-import { OTP_CODE_LIFETIME, OTP_CODE_PREFIX } from './otp-auth.constants';
+import {
+  OTP_CODE_LENGTH,
+  OTP_CODE_LIFETIME,
+  OTP_CODE_PREFIX,
+} from './otp-auth.constants';
 import { EmailsService } from 'src/modules/emails/emails.service';
 import { EMAIL_TEMPLATE } from 'src/modules/emails/emails.constants';
 import { AUTH_NO_PASSWORD } from '../auth.constants';
@@ -44,7 +48,8 @@ export class OtpAuthService {
   }
 
   async sendCode({ email }: OtpAuthSendCodeDto) {
-    const otpCode = await this.cryptService.generateHashedNumCode();
+    const otpCode =
+      await this.cryptService.generateHashedNumCode(OTP_CODE_LENGTH);
 
     try {
       await this.redisSerivce.set(`${OTP_CODE_PREFIX}:${email}`, otpCode, {

--- a/src/modules/auth/otp/otp-auth.service.ts
+++ b/src/modules/auth/otp/otp-auth.service.ts
@@ -10,27 +10,45 @@ import { CryptService } from 'src/modules/crypt/crypt.service';
 import { RedisService } from 'src/modules/redis/redis.service';
 import {
   OTP_CODE_LENGTH,
-  OTP_CODE_LIFETIME,
+  OTP_CODE_TTL,
   OTP_CODE_PREFIX,
+  OTP_LOCK_TYPE,
 } from './otp-auth.constants';
 import { EmailsService } from 'src/modules/emails/emails.service';
 import { EMAIL_TEMPLATE } from 'src/modules/emails/emails.constants';
 import { AUTH_NO_PASSWORD } from '../auth.constants';
 import { GeneralAuthService } from '../general/general-auth.service';
 import { OtpAuthDto } from './dto/otp-auth.dto';
+import { AuthAttemptsService } from '../protection/auth-attempts.service';
+import { AuthLockService } from '../protection/auth-lock.service';
+
+type LockType = 'resend' | 'default';
 
 @Injectable()
 export class OtpAuthService {
   constructor(
     private readonly cryptService: CryptService,
     private readonly prisma: PrismaService,
-    private readonly redisSerivce: RedisService,
+    private readonly redisService: RedisService,
     private readonly emailsService: EmailsService,
     private readonly generalAuthService: GeneralAuthService,
+    private readonly authAttemptsService: AuthAttemptsService,
+    private readonly authLockService: AuthLockService,
   ) {}
 
-  async auth(dto: OtpAuthDto, isRegistrationAllowed = false) {
-    await this.checkValidityCode(dto);
+  private getOtpRedisKey(email: string) {
+    return `${OTP_CODE_PREFIX}:${email}`;
+  }
+
+  async auth(
+    dto: OtpAuthDto,
+    options?: { isRegistrationAllowed?: boolean; lockType?: LockType },
+  ) {
+    const { isRegistrationAllowed = false, lockType = OTP_LOCK_TYPE } =
+      options ?? {};
+
+    await this.ensureNotLocked(dto.email, lockType);
+    await this.verifyAndConsumeCode(dto, lockType);
 
     let user = await this.prisma.user.findUnique({
       where: { email: dto.email },
@@ -47,13 +65,18 @@ export class OtpAuthService {
     return this.generalAuthService.generateTokensPair({ sub: user.id });
   }
 
-  async sendCode({ email }: OtpAuthSendCodeDto) {
+  async sendCode(
+    { email }: OtpAuthSendCodeDto,
+    lockType: LockType = OTP_LOCK_TYPE,
+  ) {
+    await this.ensureNotLocked(email, lockType);
+
     const otpCode =
       await this.cryptService.generateHashedNumCode(OTP_CODE_LENGTH);
 
     try {
-      await this.redisSerivce.set(`${OTP_CODE_PREFIX}:${email}`, otpCode, {
-        EX: OTP_CODE_LIFETIME,
+      await this.redisService.set(this.getOtpRedisKey(email), otpCode, {
+        expiration: { type: 'EX', value: OTP_CODE_TTL },
       });
     } catch {
       throw new InternalServerErrorException('Failed to save OTP code');
@@ -100,11 +123,15 @@ export class OtpAuthService {
     return user;
   }
 
-  private async checkValidityCode({ email, code }: OtpAuthDto) {
+  private async verifyAndConsumeCode(
+    { email, code }: OtpAuthDto,
+    lockType: LockType,
+  ) {
+    const redisKey = this.getOtpRedisKey(email);
     let otpCode: string | null = null;
 
     try {
-      otpCode = await this.redisSerivce.get(`${OTP_CODE_PREFIX}:${email}`);
+      otpCode = await this.redisService.get(redisKey);
     } catch {
       throw new InternalServerErrorException('Failed to get OTP code');
     }
@@ -114,9 +141,45 @@ export class OtpAuthService {
     const isSameCode = await this.cryptService.compare(code, otpCode);
 
     if (!isSameCode) {
+      await this.userLock(email, lockType);
       throw new BadRequestException('Code is incorrect');
     }
 
-    return otpCode;
+    try {
+      await this.redisService.del(redisKey);
+    } catch (e) {
+      console.log('Failed to delete verified OTP code in Redis:', {
+        e,
+        code,
+      });
+    }
+
+    await this.authAttemptsService.clear(email);
+  }
+
+  private ensureNotLocked(email: string, lockType: LockType) {
+    return lockType === 'resend'
+      ? this.authAttemptsService.ensureNotLocked(email)
+      : this.authLockService.ensureNotLocked(email);
+  }
+
+  private userLock(email: string, lockType: LockType) {
+    return lockType === 'resend'
+      ? this.blockByResendCode(email)
+      : this.blockByNewRedisKey(email);
+  }
+
+  private async blockByResendCode(email: string) {
+    const { isLocked } =
+      await this.authAttemptsService.addFailedAttemptOrBlock(email);
+
+    if (isLocked) {
+      await this.authAttemptsService.clear(email);
+      await this.sendCode({ email });
+    }
+  }
+
+  private async blockByNewRedisKey(email: string) {
+    await this.authLockService.addFailedAttemptOrBlock(email);
   }
 }

--- a/src/modules/auth/protection/auth-attempts.service.ts
+++ b/src/modules/auth/protection/auth-attempts.service.ts
@@ -1,0 +1,65 @@
+import { RedisService } from 'src/modules/redis/redis.service';
+import {
+  ATTEMPT_TTL,
+  MAX_ATTEMPTS,
+  USER_ATTEMPTS_PREFIX,
+} from './auth-protection.constants';
+import { ForbiddenException, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class AuthAttemptsService {
+  constructor(private readonly redisService: RedisService) {}
+
+  private getRedisKey(email: string) {
+    return `${USER_ATTEMPTS_PREFIX}:${email}`;
+  }
+
+  async addFailedAttemptOrBlock(
+    email: string,
+    options?: { maxAttempts?: number; attemptTime?: number },
+  ) {
+    const { maxAttempts = MAX_ATTEMPTS, attemptTime = ATTEMPT_TTL } =
+      options ?? {};
+
+    const attempts = await this.increment(email, attemptTime);
+
+    return { isLocked: attempts >= maxAttempts, attempts };
+  }
+
+  async ensureNotLocked(email: string, maxAttempts = MAX_ATTEMPTS) {
+    const attempts = await this.get(email);
+
+    if (attempts >= maxAttempts) {
+      throw new ForbiddenException(
+        'Your account has been temporarily suspended. Please try again later.',
+      );
+    }
+  }
+
+  async get(email: string) {
+    try {
+      return Number(await this.redisService.get(this.getRedisKey(email)));
+    } catch (e) {
+      console.log('Failed to get attempts', { e, email });
+      return 0;
+    }
+  }
+
+  async increment(email: string, attemptTimeSec = ATTEMPT_TTL) {
+    return await this.redisService.incrWithExpire(
+      this.getRedisKey(email),
+      attemptTimeSec,
+    );
+  }
+
+  async clear(email: string) {
+    try {
+      await this.redisService.del(this.getRedisKey(email));
+    } catch (e) {
+      console.log('Failed to delete attempts in Redis', {
+        email,
+        e,
+      });
+    }
+  }
+}

--- a/src/modules/auth/protection/auth-lock.service.ts
+++ b/src/modules/auth/protection/auth-lock.service.ts
@@ -1,0 +1,90 @@
+import { RedisService } from 'src/modules/redis/redis.service';
+import {
+  ATTEMPT_TTL,
+  LOCK_TTL,
+  MAX_ATTEMPTS,
+  USER_LOCK_PREFIX,
+} from './auth-protection.constants';
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { AuthAttemptsService } from './auth-attempts.service';
+
+@Injectable()
+export class AuthLockService {
+  constructor(
+    private readonly redisService: RedisService,
+    private readonly authAttemptsService: AuthAttemptsService,
+  ) {}
+
+  private getRedisKey(email: string) {
+    return `${USER_LOCK_PREFIX}:${email}`;
+  }
+
+  async addFailedAttemptOrBlock(
+    email: string,
+    options?: { maxAttempts?: number; attemptTime?: number; lockTime?: number },
+  ) {
+    const {
+      maxAttempts = MAX_ATTEMPTS,
+      attemptTime = ATTEMPT_TTL,
+      lockTime = LOCK_TTL,
+    } = options ?? {};
+
+    const attempts = await this.authAttemptsService.increment(
+      email,
+      attemptTime,
+    );
+
+    if (attempts >= maxAttempts) {
+      await this.createLock(email, lockTime);
+      await this.authAttemptsService.clear(email);
+
+      throw new ForbiddenException(
+        'Your account has been temporarily suspended. Please try again later.',
+      );
+    }
+  }
+
+  async ensureNotLocked(email: string) {
+    const isLocked = await this.isLocked(email);
+
+    if (isLocked) {
+      throw new ForbiddenException(
+        'Your account has been temporarily suspended. Please try again later.',
+      );
+    }
+  }
+
+  async isLocked(email: string) {
+    try {
+      return Boolean(await this.redisService.get(this.getRedisKey(email)));
+    } catch (e) {
+      console.log('Failed to get attempts', { e, email });
+      return false;
+    }
+  }
+
+  async createLock(email: string, lockTimeSec = LOCK_TTL) {
+    try {
+      await this.redisService.set(this.getRedisKey(email), '1', {
+        expiration: { type: 'EX', value: lockTimeSec },
+        condition: 'NX',
+      });
+    } catch (e) {
+      console.log('Failed to set block in Redis', {
+        email,
+        e,
+      });
+    }
+  }
+
+  async clearLock(email: string) {
+    try {
+      await this.redisService.del(this.getRedisKey(email));
+    } catch (e) {
+      console.log('Failed to clear lock in Redis', {
+        email,
+        e,
+      });
+    }
+  }
+}

--- a/src/modules/auth/protection/auth-protection.constants.ts
+++ b/src/modules/auth/protection/auth-protection.constants.ts
@@ -1,0 +1,7 @@
+export const MAX_ATTEMPTS = 5;
+export const ATTEMPT_TTL = 900; // seconds
+export const LOCK_TTL = 300; // seconds
+
+const AUTH_PREFIX = 'auth';
+export const USER_ATTEMPTS_PREFIX = `${AUTH_PREFIX}:attempts`;
+export const USER_LOCK_PREFIX = `${AUTH_PREFIX}:lock`;

--- a/src/modules/auth/protection/auth-protection.module.ts
+++ b/src/modules/auth/protection/auth-protection.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { RedisModule } from 'src/modules/redis/redis.module';
+import { AuthAttemptsService } from './auth-attempts.service';
+import { AuthLockService } from './auth-lock.service';
+
+@Module({
+  imports: [RedisModule],
+  providers: [AuthAttemptsService, AuthLockService],
+  exports: [AuthAttemptsService, AuthLockService],
+})
+export class AuthProtectionModule {}

--- a/src/modules/auth/vk/vk-auth.service.ts
+++ b/src/modules/auth/vk/vk-auth.service.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { GeneralAuthService } from '../general/general-auth.service';
 import { AuthVkDto } from './dto/auth-vk.dto';
 import { VkAuthErrorResponse, VkAuthSuccessResponse } from './vk-auth.types';
+import { AUTH_NO_PASSWORD } from '../auth.constants';
 
 @Injectable()
 export class VkAuthService {
@@ -61,7 +62,7 @@ export class VkAuthService {
     const user = await this.prisma.user.create({
       data: {
         email: randomStringGenerator() + '@vk.com',
-        hashedPassword: 'no-password',
+        hashedPassword: AUTH_NO_PASSWORD,
         vkUser: {
           create: {
             id: vkUser.id,

--- a/src/modules/crypt/crypt.service.ts
+++ b/src/modules/crypt/crypt.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
+import { randomInt } from 'node:crypto';
 
 @Injectable()
 export class CryptService {
@@ -14,5 +15,19 @@ export class CryptService {
 
   async compare(str: string, hash: string) {
     return await bcrypt.compare(str, hash);
+  }
+
+  generateNumCode(len = 6): string {
+    let code = '';
+
+    for (let i = 0; i < len; i++) {
+      code += randomInt(9).toString();
+    }
+
+    return code;
+  }
+
+  generateHashedNumCode(len = 6) {
+    return this.hash(this.generateNumCode(len));
   }
 }

--- a/src/modules/redis/redis.module.ts
+++ b/src/modules/redis/redis.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { createClient } from '@redis/client';
+import { RedisService } from './redis.service';
+
+@Module({
+  providers: [
+    {
+      provide: 'REDIS_CLIENT',
+      useFactory: () => {
+        return createClient()
+          .on('error', (err) => console.log('Redis Client Error', err))
+          .connect();
+      },
+    },
+    RedisService,
+  ],
+  exports: [RedisService],
+})
+export class RedisModule {}

--- a/src/modules/redis/redis.service.ts
+++ b/src/modules/redis/redis.service.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { RedisClientType, SetOptions } from '@redis/client';
+
+@Injectable()
+export class RedisService {
+  constructor(
+    @Inject('REDIS_CLIENT') private readonly redis: RedisClientType,
+  ) {}
+
+  set(key: string, value: string, options?: SetOptions) {
+    return this.redis.set(key, value, options);
+  }
+
+  get(key: string) {
+    return this.redis.get(key);
+  }
+}

--- a/src/modules/redis/redis.service.ts
+++ b/src/modules/redis/redis.service.ts
@@ -14,4 +14,29 @@ export class RedisService {
   get(key: string) {
     return this.redis.get(key);
   }
+
+  del(key: string) {
+    return this.redis.del(key);
+  }
+
+  async incrWithExpire(key: string, ttlSec: number) {
+    try {
+      const res = await this.redis.multi().incr(key).expire(key, ttlSec).exec();
+
+      if (!res || res[0] instanceof Error) {
+        console.log('Failed to update counter in Redis', { key, ttlSec });
+        return 0;
+      }
+
+      const incrVal = Number(res[0]);
+      return Number.isFinite(incrVal) ? incrVal : 0;
+    } catch (e) {
+      console.log('Failed to multi incr in Redis', { e, key, ttlSec });
+      return 0;
+    }
+  }
+
+  expire(key: string, seconds: number) {
+    return this.redis.expire(key, seconds);
+  }
 }


### PR DESCRIPTION
1. Добавил библиотеку @redis/client для подключения к Redis
2. Создал Redis модуль. Обернул Redis Client в RedisService
3. В CryptService добавил две новые функции. Генерация рандомных чисел - generateNumCode и их хэширование - generateHashedNumCode
4. Перевел "no-password" в константу AUTH_NO_PASSWORD создав auth.constatns.ts
5. Создал OTPModule
6. Добавлен параметр `isRegistrationAllowed` позволяющий автоматически регистрировать пользователя или отказывать в авторизации

# Что изменилось с изначальной ревизии
1. Добавлен пакет `@nestjs/throttler`
2. Прописаны глобальные ограничения для ThrottlerModule: 60 запросов в 1 минуту
3. Прописаны более строгие ограничения по Throttle
3.1 BasicAuth: `/login` = 5 запросов в 1 минуту, `/register` = 5 запросов в час
3.2 OTP: на `/send-code` и `/login` = 5 запросов в минуту
4. Добавлена константа `OTP_CODE_LENGTH` для регулирования длины кода при проверке и генерации кода
5. Добавлены новые методы в `RedisService`: `incrWithExpire, expire, del`
7. Создан новый модуль `AuthProtection`. В нем существует два сервиса: 
6.1 `AuthAttempts` - служит для управления неудачными попытками
6.2 `AuthLock` - служит для управления блокировкой аккаунта
8. Для нового модуля `AuthProtection` созданы новые константы:
7.1 `MAX_ATTEMPTS` - максимальное количество попыток
7.2 `ATTEMPT_TTL` - время жизни ключа неудачных попыток в сек. (дефолтно: 15 мин)
7.3 `LOCK_TTL` - время жизни блокировки пользователя в сек. (дефолтно 5 мин)
7.4 Префиксы ключей для хранения в Redis: `USER_ATTEMPTS_PREFIX` и `USER_LOCK_PREFIX`
9. Для OTP модуля создана новая логика выбора и система блокировок

## Новая логика в OTP модулей со связкой Protection модуля
1. Создана логика переключения между блокировками. Есть два вида блокировки:
1.1 lockType = `resend`. Пользователь превысив максимальное кол-во вместо блокировки получает новый код
1.2 lockType = `default`. Пользователь превысив максимальное кол-во получает бан на 5 мин. И в течение этого времени получает 403 ошибку пытаясь дергать точки `/send-code` или `/login`
2. По умолчанию установлена блокировка `lockType` = `default` через константу `OTP_LOCK_TYPE`
3. Теперь при запросе `/send-code` или `/login` происходит проверка заблокирован ли пользователь через внутреннюю функцию OTP модуля `ensureNotLocked`
4. Функция `ensureNotLocked` проверяет тип блокировки и вызывает соответствующие проверки блокировки сервисов: `authAttemptsService.ensureNotLocked` или `authLockService.ensureNotLocked`
4.1 `authAttemptsService.ensureNotLocked` - если пользователь превысил кол-во доступных попыток, то отдаем 403. Но на данный момент это невозможно, т.к. как только пользователь превысит порог он получит новое письмо с новым кодом, а кол-во попыток сотрутся 
4.2 `authLockService.ensureNotLocked` - проверяет есть ли ключ `auth:lock:${email}`. Если есть значит пользователь заблокирован, отдаем 403
5. Если пользователь ошибается при вводе кода через `/login`, то отрабатывает функция `userLock`. Она проверяет какой тип блокировки выбран `lockType` и в зависимости от этого запускает функции:
5.1 `lockType=resend` -> запуск `blockByResendCode`. Увеличивает счетчик неудачных попыток и при достижении макс. порога очищает ключ попыток из Redis и **заново создает и отправляет новый код**
5.2 `lockType=default` -> запуск `blockByNewRedisKey`. Увеличивает счетчик неудачных попыток и при достижении макс. порога очищает ключ попыток из Redis и **создает ключ блокировки и отдает ошибку 403** 

## Интересные сценарии
1. lockType = default. Пользователь заходит в первый раз и получает код. Он перебирает 5 попыток и блокируется на 5 мин. Теперь он знает, что дается 5 попыток. В следующий раз он получает новый код, но вводит 4 неудачные попытки и сразу бежит получать новый код, чтобы избежать блокировки. Получает новый код, но ведя один раз код - он блокируется на 5 мин. - я так сделал, просто не удаляю ключ попыток из Redis при отправке нового кода каждый раз. В итоге у пользователя при такой блокировке есть итоговые 5 попыток на любые попытки авторизации через OTP-код. Но у ключа неудачных попыток в Redis TTL = 15 мин, поэтому через 15 минут он может начать все с чистого листа 
2. Нужно ребятам рассказать про фиксированное и скользящее окно
